### PR TITLE
use service generic exception instead of swagger client exception

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -327,7 +327,7 @@ public class DefaultCodegen {
         typeMapping.put("object", "Object");
         typeMapping.put("integer", "Integer");
         typeMapping.put("ByteArray", "byte[]");
-        typeMapping.put("LocalDate", "java.time.LocalDate");
+        typeMapping.put("Date", "java.time.LocalDate");
         typeMapping.put("URI", "java.net.URI");
 
         instantiationTypes = new HashMap<String, String>();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -195,6 +195,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
         //supportingFiles.add(new SupportingFile("gradle.properties.mustache", "", "gradle.properties"));
         supportingFiles.add(new SupportingFile("ApiClient.mustache", invokerFolder, "ApiClient.java"));
         supportingFiles.add(new SupportingFile("StringUtil.mustache", invokerFolder, "StringUtil.java"));
+        supportingFiles.add(new SupportingFile("ServiceException.mustache", invokerFolder, "ServiceException.java"));
 
         final String authFolder = (sourceFolder + File.separator + invokerPackage + ".auth").replace(".", File.separator);
         supportingFiles.add(new SupportingFile("auth/HttpBasicAuth.mustache", authFolder, "HttpBasicAuth.java"));

--- a/modules/swagger-codegen/src/main/resources/Java/ServiceException.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ServiceException.mustache
@@ -2,15 +2,17 @@ package {{invokerPackage}};
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
-
+import lombok.Setter;
+import lombok.ToString;
 import javax.ws.rs.core.Response;
 import java.util.Map;
 import java.util.List;
 
-@Data
+@Getter
+@Setter
+@ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/modules/swagger-codegen/src/main/resources/Java/ServiceException.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ServiceException.mustache
@@ -1,0 +1,26 @@
+package {{invokerPackage}};
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+{{>generatedAnnotation}}
+public class ServiceException extends RuntimeException {
+
+    private Map<String, List<String>> responseHeaders = null;
+    private String errorCode;
+    private Response.Status statusCode;
+    private String message;
+    private Object[] args;
+}
+

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -416,7 +416,7 @@ public class ApiClient {
    * @param returnType The return type into which to deserialize the response
    * @return The response body in type of string
    */
-  public <T> T invokeAPI(String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, TypeRef returnType) throws ApiException {
+  public <T> T invokeAPI(String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, TypeRef returnType) throws Exception {
     updateParamsForAuth(authNames, queryParams, headerParams);
 
     final ClientConfig clientConfig = new ClientConfig();
@@ -520,20 +520,16 @@ public class ApiClient {
         return deserialize(response, returnType);
     } else {
       String message = "error";
-      String respBody = null;
+      ServiceException serviceException = null;
       if (response.hasEntity()) {
         try {
-          respBody = String.valueOf(response.readEntity(String.class));
-          message = respBody;
+          serviceException = response.readEntity(ServiceException.class);
+          serviceException.setResponseHeaders(responseHeaders);
         } catch (RuntimeException e) {
           // e.printStackTrace();
         }
       }
-      throw new ApiException(
-        response.getStatus(),
-        message,
-        buildResponseHeaders(response),
-        respBody);
+      throw serviceException;
     }
   }
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -41,7 +41,7 @@ public class {{classname}} {
 {{#allParams}}   * @param {{paramName}} {{description}}
 {{/allParams}}   * @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
    */
-  public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
+  public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws Exception {
     Object {{localVariablePrefix}}postBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
     {{#allParams}}{{#required}}
     // verify the required parameter '{{paramName}}' is set

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
@@ -73,7 +73,7 @@ public class JavaModelTest {
         Assert.assertEquals(property3.baseName, "createdAt");
         Assert.assertEquals(property3.getter, "getCreatedAt");
         Assert.assertEquals(property3.setter, "setCreatedAt");
-        Assert.assertEquals(property3.datatype, "Date");
+        Assert.assertEquals(property3.datatype, "java.time.LocalDate");
         Assert.assertEquals(property3.name, "createdAt");
         Assert.assertEquals(property3.defaultValue, "null");
         Assert.assertEquals(property3.baseType, "Date");


### PR DESCRIPTION
use service generic exception instead of swagger client exception

also map date type in json to java LocalDate object

@Blackbaud-RyanMcKay @Blackbaud-EricSlater @blackbaud/constituent-service 
