### PR TITLE
LUM-1441-Generated Swagger client accepts and propagates correlation id

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/StringUtil.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/StringUtil.mustache
@@ -49,11 +49,8 @@ public class StringUtil {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public static boolean isNotBlank(String s){
-    if(s != null && !s.trim().equals("")){
-      return true;
-    } 
-    return false;
+  public static boolean isBlank(String s){
+    return (s == null || s.trim().isEmpty());
   }
 
 }

--- a/modules/swagger-codegen/src/main/resources/Java/StringUtil.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/StringUtil.mustache
@@ -48,4 +48,12 @@ public class StringUtil {
     if (o == null) return "null";
     return o.toString().replace("\n", "\n    ");
   }
+
+  public static boolean isNotBlank(String s){
+    if(s != null && !s.trim().equals("")){
+      return true;
+    } 
+    return false;
+  }
+
 }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -38,6 +38,8 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.text.ParseException;
 
+import org.slf4j.MDC;
+
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
@@ -45,6 +47,10 @@ import {{invokerPackage}}.auth.OAuth;
 
 {{>generatedAnnotation}}
 public class ApiClient {
+
+  private static final String MDC_CORRELATION_LABEL = "correlationId";
+  private static final String HEADER_CORRELATION_LABEL = "X-Trace-Id";
+
   private Map<String, Client> hostMap = new HashMap<String, Client>();
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
   private boolean debugging = false;
@@ -456,6 +462,12 @@ public class ApiClient {
           invocationBuilder = invocationBuilder.header(key, value);
         }
       }
+    }
+
+    //set correlation Id header
+    String correlationId = MDC.get(MDC_CORRELATION_LABEL);
+    if(StringUtil.isNotBlank(correlationId)){
+      invocationBuilder.header(HEADER_CORRELATION_LABEL, correlationId);
     }
 
     Entity<?> formEntity = null;

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -48,7 +48,7 @@ import {{invokerPackage}}.auth.OAuth;
 {{>generatedAnnotation}}
 public class ApiClient {
 
-  private static final String MDC_CORRELATION_LABEL = "correlationId";
+  private static final String MDC_CORRELATION_LABEL = "X-Trace-Id";
   private static final String HEADER_CORRELATION_LABEL = "X-Trace-Id";
 
   private Map<String, Client> hostMap = new HashMap<String, Client>();
@@ -464,10 +464,9 @@ public class ApiClient {
       }
     }
 
-    //set correlation Id header
-    String correlationId = MDC.get(MDC_CORRELATION_LABEL);
-    if(StringUtil.isNotBlank(correlationId)){
-      invocationBuilder.header(HEADER_CORRELATION_LABEL, correlationId);
+    String traceId = MDC.get(MDC_CORRELATION_LABEL);
+    if(!StringUtil.isBlank(traceId)){
+      invocationBuilder.header(HEADER_CORRELATION_LABEL, traceId);
     }
 
     Entity<?> formEntity = null;


### PR DESCRIPTION
add correlation id from mdc to request in header. The client uses a custom string utils and I feel like my isNotBlank is hacky... 
these changes have been generated and applied to the dojo service in this PR
https://github.com/blackbaud/bluemoon-dojo/pull/80

@Blackbaud-RyanMcKay @Blackbaud-IsaacAggrey @Blackbaud-ChristopherCotar @Blackbaud-JohnHolland @Blackbaud-MikeLueders
